### PR TITLE
Update about content and improve blog styling

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -2,4 +2,12 @@
 name: Luciano Tourn
 ---
 
-Emprendedor de la salud. Co-fundador en [Wúru](https://www.wuru.ai/) y Director en Grupo Gamma
+Soy ante todo una persona curiosa. Me interesan las ideas, me interesa la gente que tiene buenas ideas, que profundiza en entender esas ideas y que las puede llevar a la práctica para cambiar la realidad.
+
+Me gusta armar organizaciones que crean productos y servicios de calidad. Estoy enfocado cien por ciento en la salud, un sector que me apasiona por la combinación de humanismo, tecnología, complejidad e impacto en la vida de las personas.
+
+Cofundé Wúru, donde hacemos productos de sofware que potencian al equipo de salud en su flujo de trabajo diario, para liberar el tiempo de la burocracia y tareas repetitivas, y destinarlo al paciente y sus necesidades. También dirijo Gamma, un grupo prestador que fundó Mario, mi viejo, y que ahora desarrollamos con mis hermanos en esta nueva etapa.
+
+Soy papá de Juli y Santi, y acompañarlos en su crecimiento es lo mejor que tiene la vida. Creo que ellos van a ser protagonistas de una Argentina grande en el siglo XXI. Vamos a volver a tener un lugar de liderazgo en el mundo porque acá hay gente con talento, resiliencia, creatividad y pertenencia.
+
+Quise armar este espacio para compartir ideas en un formato más extenso y profundo que lo que permiten las redes sociales. Una iniciativa que suena contracultural, pero al mismo tiempo la veo necesaria si es que queremos elaborar cosas más alla del slogan. Espero que funcione.

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -23,9 +23,6 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
       </div>
 
       <div className="mb-8">
-        <div className="text-black opacity-70 leading-relaxed">
-          <strong>{post.title}</strong>
-        </div>
         <div className="text-black opacity-30 leading-relaxed">
           {post.date}
         </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -97,15 +97,15 @@ body {
 }
 
 .prose a {
-  color: #374151;
+  color: #2563eb;
+  font-weight: bold;
   text-decoration: underline;
-  text-decoration-color: #d1d5db;
+  line-height: 1;
   transition: all 0.2s;
 }
 
 .prose a:hover {
-  color: #111827;
-  text-decoration-color: #374151;
+  color: #60a5fa;
 }
 
 .prose blockquote {


### PR DESCRIPTION
## Summary
- Expanded `about.md` with detailed personal bio covering background, vision for Argentina, and purpose of the blog
- Updated prose link styles to use blue color (`#2563eb`) with bold weight for better visibility
- Removed duplicate title display from blog post page (title was showing twice)
- Made `excerpt` field optional in blog posts and added automatic title extraction from H1 heading if not specified in frontmatter

## Test plan
- [ ] Verify about page displays the expanded bio correctly
- [ ] Check that links in prose content appear blue and bold
- [ ] Confirm blog posts show title only once
- [ ] Test blog posts without explicit title in frontmatter to verify H1 extraction works

🤖 Generated with [Claude Code](https://claude.com/claude-code)